### PR TITLE
fix(ui): improve CardHeader flex layout responsiveness

### DIFF
--- a/src/components/crypto/charts/price-chart.tsx
+++ b/src/components/crypto/charts/price-chart.tsx
@@ -99,7 +99,7 @@ export function PriceChart({ coinId, compareCoinId }: PriceChartProps) {
 
   return (
     <Card className="w-full h-[595px]">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+      <CardHeader className="flex flex-col md:flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-xl font-bold">Price History</CardTitle>
         <TimeRangeSelector
           selectedRange={timeRange}


### PR DESCRIPTION
# Description
Fix the CardHeader layout to be responsive by switching to a vertical column layout on mobile devices.

# Changes
- Change CardHeader from `flex-row` to `flex-col` on smaller screens.

